### PR TITLE
Syntax Error causes routing error

### DIFF
--- a/app/routes/specific-activity.js
+++ b/app/routes/specific-activity.js
@@ -34,7 +34,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         let leaders = getSync("/memberships/activity/" + param.ActivityCode + "/leaders", this).data;
         for (var i = 0; i < leaders.length; i ++) {
             if (leaders[i].SessionCode !== param.SessionCode) {
-                leader.splice(i --, 1);
+                leaders.splice(i --, 1);
             }
             else if (leaders[i].IDNumber == IDNumber) {
                 leading = true;


### PR DESCRIPTION
On activities with leaders in the previous session, syntax error causes huge blowout. 
fixed.
