### PR TITLE
Add VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "type": "npm",
+        "script": "test",
+        "group": {
+          "kind": "test",
+          "isDefault": true
+        }
+      },
+      {
+        "type": "npm",
+        "script": "start",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
This allows developers using Visual Studio Code to use hotkeys to trigger the dev server and tests.